### PR TITLE
Fix positioning in pod leader section

### DIFF
--- a/_includes/pod_leader.html
+++ b/_includes/pod_leader.html
@@ -1,7 +1,7 @@
 {% for item in site.data.pod_leader %}
 <div class="leader">
     <div class="leader_row">
-        <div class="leader_column">
+        <div class="leader_image">
             <img src="{{ site.baseurl }}/assets/img/{{ item.pic }}">
         </div>
         <div class="leader_column">

--- a/_sass/pod_leader.scss
+++ b/_sass/pod_leader.scss
@@ -2,7 +2,7 @@
 
 .leader  {
         width: 100%;
-        padding: 15px;
+        padding: 60px 15px;
         margin-right: auto;
         margin-left: auto;
         background: linear-gradient(#1c1e26,#0a0a0a);
@@ -31,6 +31,15 @@
     margin-left: -15px;
 }
 
+.leader_image {
+    -ms-flex: 0 0 50%;
+    flex: 0 0 50%;
+    max-width: 40%;
+    padding:20px;
+    text-align: center;
+    vertical-align: middle;
+}
+
 .leader_column {
     -ms-flex: 0 0 50%;
     flex: 0 0 50%;
@@ -39,7 +48,7 @@
     text-align: center;
 }
 
-.leader_column img{
+.leader_image img{
     max-width: 100%;
     height: auto;
     border-radius: 50%;


### PR DESCRIPTION
Changed the positioning a bit in the pod leader section.

### Before
Earlier the image was slightly more to the center. Also needed a bit more padding.

![image](https://user-images.githubusercontent.com/53087550/106918668-6923a680-672f-11eb-8971-f00d73077d86.png)


### After
Divided the image and text section width in 2:3 ratio. Added more padding.

![image](https://user-images.githubusercontent.com/53087550/106918491-40031600-672f-11eb-8b3b-bc44ce489cfa.png)
