### PR TITLE
solve uncomplete screen width bug

### DIFF
--- a/_includes/footer_minimal.html
+++ b/_includes/footer_minimal.html
@@ -1,6 +1,6 @@
 <div id="footer_body">
     <footer class="mh-100">
-        <svg class="svg svg-top" xmlns="http://www.w3.org/2000/svg" width="1200" fill="#f9fcfe" height="30" viewBox="0 0 1200 30" preserveAspectRatio="none">
+        <svg class="svg svg-top" xmlns="http://www.w3.org/2000/svg" fill="#f9fcfe" height="30" preserveAspectRatio="none">
 			<path d="M0,0S1.209,1.508,200.671,7.031C375.088,15.751,454.658,30,600,30V0H0ZM1200,0s-90.21,1.511-200.671,7.034C824.911,15.751,745.342,30,600,30V0h600Z"></path>
 		</svg>	
         <p class="text-center">

--- a/_includes/footer_minimal.html
+++ b/_includes/footer_minimal.html
@@ -11,6 +11,6 @@
         </div>
         {% include social_media_links.html %}
         <hr id="break_line">
-        <p class="footercolor text-center "> 2021 All Right Reserved. Copyright @Swift megaminds </p>
+        <p class="footercolor text-center " id="footer-xtmbttm"> 2021 All Right Reserved. Copyright @Swift megaminds </p>
     </footer>
 </div>

--- a/_sass/footer_minimal.scss
+++ b/_sass/footer_minimal.scss
@@ -41,5 +41,9 @@ $font_color:#686b6f;
     font-size:20px;color:#6b6969;
 }
 
+#footer-xtmbttm{
+    margin: 0px !important;
+    padding-bottom: 1em;
+}
 
 #svg-top{width:100%;display:block;position:absolute;left:0;top:-1px;}

--- a/_sass/hero.scss
+++ b/_sass/hero.scss
@@ -10,7 +10,6 @@
 	-webkit-box-direction: normal;
 	-ms-flex-direction: column;
 	flex-direction: column;
-	min-width: 100vw;
 	overflow: hidden;
     .hero-text {
 		margin: auto auto;


### PR DESCRIPTION
# Problem Solved

@amalaabraham I assume when you added the footer you forgot to unset the attributes in the html; it caused the ```<p>``` to have a width > %100; there was also an unneeded bottom margin I set off

there's still a sort of the same issue but that one is due to the irresponsiveness of the pod-leader description text

<img width="901" alt="Screen Shot 2021-02-04 at 10 37 05 PM" src="https://user-images.githubusercontent.com/50892933/106958669-f7048f00-6739-11eb-97f1-2c2e67164490.png">
